### PR TITLE
rfc(filesystem integration): couple qri datasets with a folder on the local file system

### DIFF
--- a/text/0000-filesystem-integration.md
+++ b/text/0000-filesystem-integration.md
@@ -1,0 +1,72 @@
+- Feature Name: Filesystem Integration
+- Start Date: 2019-07-02
+- RFC PR:
+- Issue:
+
+# Summary
+[summary]: #summary
+
+Adds filesystem integration to qri datasets including a current working directory context for some qri commands.  The goal is to provide an experience that is more analogous to the git workflow, where working changes to files are sensed prior to committing a new version.
+
+# Motivation
+[motivation]: #motivation
+
+The motivation for this feature is to provide a more tangible connection between the qri versioning/publishing ecosystem and the file-based data that data practitioners are used to working with. Since all of the information in a qri dataset maps to files, we should just make those files exist automatically when a qri dataset is "added" to the user's local machine.  Likewise, we should watch for changes to those files, and ensure that they are all in a valid state before allowing the user to commit changes to a qri dataset.
+
+*This will significantly lower the barrier to entry for new users to qri, especially GUI users, as they can quickly pull down published datasets and begin working with them without having to understand how IPFS/QRI stores and maintains the data.*  
+
+# Guide-level explanation
+[guide-level-explanation]: #guide-level-explanation
+
+The intent is to create a workflow more analogous with the git workflow.  When a new user wants the files in a remote git repo, they use `git clone {repoUrl}` and a new directory is created on their filesystem containing those files.  They can use _whatever tooling they want_ to make changes to the files, and commit them locally when they reach a critical point.
+
+We want the qri dataset user to have a similar experience: `qri add /b5/world_bank_population/` should create a new directory called `world_bank_population` on the filesystem, containing the following files:
+
+- `body.csv`
+- `meta.json`
+- `structure.json`
+- `transform.star`
+
+To change the dataset, the user uses _whatever tooling they want_ to modify the files, then commits the changes.
+
+## Commands
+
+Under this proposal, `qri use` is no longer relevant, as qri commands should be run from the qri dataset's directory.
+
+- `qri add` - creates a copy of the dataset's files in the present working directory
+- `qri status` - provides a report of the current state of the files in the current directory versus the last commit to the dataset
+- `qri save` - commits changes on the current dataset, and should throw errors if the changes to be committed are not valid
+
+## Strict Filenames
+
+This feature allows for qri datasets to live anywhere on the user's filesystem, and be mixed-in with other files and folders.  The initial implementation should require the strict filenames and extensions listed above (with the exception that `body` can have extension csv, json, xlsx, etc)
+
+This means `qri status` and `qri save` should ignore any non-qri files in the dataset directory.
+
+# Reference-level explanation
+[reference-level-explanation]: #reference-level-explanation
+
+- Something about the invisible `.qri-ref` file that links the current directory to the central qri store
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+- More overhead around the core qri service
+- Permissions/Cross-platform filesystem issues?
+
+# Rationale and alternatives
+[rationale-and-alternatives]: #rationale-and-alternatives
+
+This design is preferable because it makes Qri more relatable to data consumers who are used to working with data files.  It also emulates the established and popular workflow of git.
+
+If we don't do this, qri users have the additional burden of manually exporting qri components to files, and must use more advanced commands/tooling/scripting to commit changes to a dataset. _This proposal opens up the universe of qri-compatible tools to anything that can save json and csv files to the filesystem_
+
+This feature is also critical to the desired GUI for Qri, which would make the Qri frontend behave more like Github Desktop.  The Qri frontend will clone, validate commits, show diffs, allow for pushing and publishing, etc.  Some basic editing will be possible via the frontend, but most users will move to another environment to actually make changes.
+
+# Prior art
+[prior-art]: #prior-art
+
+Git is the inspiration for this model, specifically the idea that cloning a repository results in new files on the local machine that can be modified and subsequently committed as a new version.
+
+# Unresolved questions
+[unresolved-questions]: #unresolved-questions

--- a/text/0000-filesystem-integration.md
+++ b/text/0000-filesystem-integration.md
@@ -60,7 +60,13 @@ Notes:
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
 
-- Something about the invisible `.qri-ref` file that links the current directory to the central qri store
+When a filesystem folder is linked to a qri dataset, we create a file `.qri-ref` in that directory. This file contains a full path to the qri dataset (peername, dataset name, profile id, network, version hash). Every command that normally allows for `use` refs, will check for the presence of this file, and if found, will use that dataset reference contained within to pass along to the command's arguments.
+
+Running `diff` would compare the working directory against the head version of the dataset, using the existing diff lib functionality.
+
+Running `status` would compare the same, but only as a binary yes/no "are they the same?" comparison, to display if the working directory is dirty or clean.
+
+Running `save` would save using the dataset.yaml and body.csv in the working directory as file parameters.
 
 # Drawbacks
 [drawbacks]: #drawbacks

--- a/text/0000-filesystem-integration.md
+++ b/text/0000-filesystem-integration.md
@@ -30,7 +30,7 @@ This is a 1-1 relationship, a dataset can only link to one directory on the file
 
 ## Files
 
-The following files abstract the qri dataset model, providing well-named and isolated files for the most recognizable parts of the dataset.
+The following files abstract the qri dataset model, providing well-named files for the most recognizable parts of the dataset.
 
 ### `meta.json`
 
@@ -46,24 +46,60 @@ The data file!
 
 ### `dataset.json`
 
-A subset of the full qri `dataset.json` with only user-editable keys: `meta`, `structure`, `transform`.  Everything else is managed by qri behind the scenes.
+Any additional uncontrolled `dataset` fields.  This file will probably not be used by novice users.  Users who are more familiar with the dataset model can use this file to add advanced configuration.
+
+### `.qri-ref`
+
+An invisible file used to specify the link between the current directory and the Qri repo.
 
 ## Commands
 
-- `qri init {name}` - creates an "empty" qri dataset in the user's local ipfs repo, adds a directory `/{name}` in the present working directory, links that directory to the qri dataset and populates an empty `dataset.json`
+- `qri init` - interactive prompt that sets up a qri dataset with linked files in the current directory. (User should have already created a directory to hold the dataset, `cd` into it, then run `qri init`)
 
-- `qri clone` - hybrid command that adds an existing dataset to the user's local IPFS repo _AND_ creates a linked working directory on the filesystem.  
+This should have an `non-interactive` flag that only needs a dataset name, which will link an empty dataset working directory to a name reference in the qri repo. (reserving the name for a future commit)
 
-- `qri status` - provides a report of the current state of the files in the current directory versus the last commit to the dataset.  Validates changes and gives a green light if everything is ready to be committed.
+### Prompts:
+  -  **Dataset Name** - (autopopulate with the name of the current directory) generates `meta.json` in the working directory with the supplied name as `title` and boilerplate `description`, `keywords`, etc
+
+  -  **File Type** - csv/json? Based on the user's selection, add dummy `body.csv|json` and `schema.json` to the working directory.
+
+- `qri clone` - hybrid command that adds an existing dataset to the user's local Qri repo _AND_ creates a linked working directory on the filesystem.  
+
+- `qri status` - provides a report of the current state of the files in the working directory versus the last commit to the dataset.  Validates changes and gives a green light if everything is ready to be committed.
+
+  - `.qri-ref`
+    - If this file doesn't exist, notify the user that they are not in a qri dataset directory
+    - If it does, provide info about the dataset and version this directory is linked to
+
+  - `body.csv|json`
+    - No changes/XX changes
+    - valid schema/XX schema violations
+    - error if not parsable CSV/JSON etc
+
+  - `meta.json`
+    - No changes/XX changes
+    - warning if missing suggested minimum metadata fields
+    - error if invalid
+
+  - `schema.json`
+    - No changes/XX changes
+    - error if invalid JSON schema
+
+  - `dataset.json`
+    - No changes/XX changes
+    - error if invalid
+
+
+- `qri log` - show the log of commits for the current dataset
 
 - `qri checkout {hash}` - change the files in the working directory to reflect a previous version of the qri dataset
 
-- `qri commit|save` - commits changes on the current dataset, and should throw errors if the changes to be committed are not valid for a commit
+- `qri commit|save` - commits changes on the current dataset, ensures that the working directory reflects the version of the dataset after the commit (e.g. if there was no `schema.json` because the user just initialized an empty working directory)
 
 Notes:
 - `qri add` - May cause confusion because it does not work the same way as `git add` as qri has no staging area.  For now it should remain unchanged, `qri add` will add the dataset to the user's local IPFS repo but will not create a linked directory on the filesystem.
 
-- `qri use` can still work, but if the user is currently in a linked qri dataset directory, all commands should assume the user is working with the current dataset
+- `qri use` can still work, but if the user is currently in a linked qri dataset directory, all commands should assume the user is working with the linked dataset
 
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation

--- a/text/0000-filesystem-integration.md
+++ b/text/0000-filesystem-integration.md
@@ -11,7 +11,7 @@ This feature adds a "live link" between a qri dataset in the user's IPFS repo an
 # Motivation
 [motivation]: #motivation
 
-The motivation for this feature is to provide a more tangible connection between the qri versioning/publishing ecosystem and the file-based data that data practitioners are used to working with. Since all of the information in a qri dataset maps to files, we should just make those files exist automatically when a qri dataset is "added" to the user's local machine.  Likewise, we should watch for changes to those files, and ensure that they are all in a valid state before allowing the user to commit changes to a qri dataset.
+The motivation for this feature is to provide a more tangible connection between the qri versioning/publishing ecosystem and the file-based data that data practitioners are used to working with. Since all of the user-modifiable information in a qri dataset can map to files, we should just make those files exist on the filesystem.  Likewise, we should watch for changes to those files, and ensure that they are all in a valid state before allowing the user to commit changes to a qri dataset.
 
 *This will significantly lower the barrier to entry for new users to qri, especially GUI users, as they can quickly pull down published datasets and begin working with them without having to understand how IPFS/QRI stores and maintains the data.*  
 
@@ -30,15 +30,23 @@ This is a 1-1 relationship, a dataset can only link to one directory on the file
 
 ## Files
 
-A dataset directory should contain only two files, all other files will be ignored by qri.
+The following files abstract the qri dataset model, providing well-named and isolated files for the most recognizable parts of the dataset.
 
-### `dataset.json`
+### `meta.json`
 
-A subset of the full qri `dataset.json` with only user-editable keys: `meta`, `structure`, `transform`.  Everything else is managed by qri behind the scenes.
+The dataset's `meta` component.
+
+### `schema.json`
+
+The dataset's `structure.schema` component
 
 ### `body.[csv|json|xlsx]`
 
 The data file!
+
+### `dataset.json`
+
+A subset of the full qri `dataset.json` with only user-editable keys: `meta`, `structure`, `transform`.  Everything else is managed by qri behind the scenes.
 
 ## Commands
 


### PR DESCRIPTION
Adds filesystem integration to qri datasets including a current working directory context for some qri commands.  

The goal is to provide an experience that is more analogous to the git workflow, where cloning produces files on the local filesystem, and working changes to files are sensed prior to committing a new version.